### PR TITLE
必要なライブラリをdockerfileにおいて、package.jsonから読み込むようにする

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -2,5 +2,9 @@ FROM node:22-alpine3.19
 
 WORKDIR /app/
 
-COPY ./package.json ./
+COPY package*.json ./
 RUN npm install
+
+COPY . .
+
+CMD ["npm", "run", "dev"]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "next": "14.2.13",
     "react": "^18",
     "react-dom": "^18",
-    "react-draggable": "^4.4.6"
+    "react-draggable": "^4.4.5"
   },
   "devDependencies": {
     "@types/node": "20.16.10",


### PR DESCRIPTION
## 概要
- `react-draggable`を読み込めていない状況であった。
-  dockerfileに、`package.json`から読み込むことでエラーが解消された。


## 検証方法

1.以下のコマンドを実行
``` 
docker-compose build --no-cache
docker-compose up
```

2. `http://localhost:12000/`をブラウザで開く