### PR TITLE
コンポーネントを選択できるようにする

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,17 @@
 "use client";
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './styles/global.css';
 import { NodeBox } from '../components/NodeBox';
 import { ConnectionLines } from '../components/ConnectionLines';
 import { useNodeSystem } from '../hooks/useNodeSystem';
 import vertexShader from './shaders/vertex.wgsl';
 import fragmentShader from './shaders/fragment.wgsl';
+import { ComponentSelector } from '../components/ComponentSelector';
 
 const Home = () => {
-  const canvasRef = useRef(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
   const nodeSystem = useNodeSystem();
+  const [isSelectorOpen, setIsSelectorOpen] = useState(false);
 
   useEffect(() => {
     const initializeWebGPU = async () => {
@@ -98,7 +100,7 @@ const Home = () => {
           colorAttachments: [
             {
               view: textureView,
-              // 背景を指定
+              // 背景を定
               clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
               // ロード操作を指定
               // 'load': 前のフレームからの描画結果が維持
@@ -116,7 +118,7 @@ const Home = () => {
         // GPUコマンドの記録開始
         const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor)
         // レンダーパイプラインを設定
-        // これにより、使用するシェーダーとレンダリング設定が指定される
+        // これによ、使用するシェーダーとレンダリング設定が指定される
         passEncoder.setPipeline(pipeline)
         // レンダリング開始
         passEncoder.draw(3)
@@ -141,13 +143,7 @@ const Home = () => {
         <div className="left">Component Editor</div>
         <div className="right">
           <button 
-            onClick={() => {
-              const id = `node-${Object.keys(nodeSystem.nodes).length}`;
-              nodeSystem.addNode(id, {
-                x: Math.random() * 300,
-                y: Math.random() * 200
-              });
-            }} 
+            onClick={() => setIsSelectorOpen(true)} 
             className="button primary"
           >
             Add Node
@@ -158,20 +154,24 @@ const Home = () => {
       </header>
 
       <div className="content">
-        <div 
-          className="canvas-container">
-          <canvas ref={canvasRef} className="webgpu-canvas" />
-          </div>
-
-        <div className="properties-panel">
-          <h2 className="properties-title">Properties</h2>
-          <div className="node-system-container" 
-              onMouseMove={nodeSystem.updateDraggingConnection}
-              onMouseUp={nodeSystem.clearDraggingConnection}>
-            <ConnectionLines 
+        <div className="canvas-container">
+          <canvas 
+            ref={canvasRef}
+            className="webgpu-canvas"
+          />
+        </div>
+        
+        <div className="node-system-container">
+          <div 
+            className="canvas"
+            onMouseMove={nodeSystem.updateDraggingConnection}
+            onMouseUp={nodeSystem.clearDraggingConnection}
+          >
+            <ConnectionLines
               nodes={nodeSystem.nodes}
               draggingConnection={nodeSystem.draggingConnection}
             />
+            
             {Object.entries(nodeSystem.nodes).map(([id, node]) => (
               <NodeBox
                 key={id}
@@ -184,18 +184,21 @@ const Home = () => {
               />
             ))}
           </div>
-          <div className="properties-list">
-            {Object.entries(nodeSystem.nodes).map(([id, node]) => (
-              <div key={id} className="property-item">
-                <h3 className="property-name">Node {id}</h3>
-                <div className="property-value">
-                  x: {Math.round(node.position.x)}, y: {Math.round(node.position.y)}
-                </div>
-              </div>
-            ))}
-          </div>
         </div>
       </div>
+
+      <ComponentSelector
+        isOpen={isSelectorOpen}
+        onClose={() => setIsSelectorOpen(false)}
+        onSelect={(componentType) => {
+          const id = `node-${Date.now()}`;
+          nodeSystem.addNode(id, {
+            x: Math.random() * 300,
+            y: Math.random() * 200,
+            componentType,
+          });
+        }}
+      />
     </div>
   );
 };

--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -3,28 +3,33 @@
   display: flex;
   flex-direction: column;
   font-family: Arial, sans-serif;
+  background-color: #1e1e1e;
 }
 
 .header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background-color: #ccc;
-  padding: 10px;
+  padding: 16px 24px;
+  background-color: #2d2d2d;
+  border-bottom: 1px solid #404040;
 }
 
 .left {
-  font-size: 16px;
+  font-size: 18px;
+  font-weight: bold;
+  color: white;
 }
 
 .right {
   display: flex;
-  gap: 20px;
+  gap: 12px;
 }
 
 .content {
   display: flex;
   flex: 1;
+  position: relative;
 }
 
 .canvas-container {
@@ -40,25 +45,24 @@
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 1;
 }
 
 .button {
   padding: 8px 16px;
   border-radius: 4px;
-  border: 1px solid #ccc;
-  background-color: white;
+  border: 1px solid #404040;
+  background-color: #3d3d3d;
+  color: white;
   cursor: pointer;
   transition: all 0.2s;
 }
 
 .button:hover {
-  background-color: #f0f0f0;
+  background-color: #4d4d4d;
 }
 
 .button.primary {
   background-color: #4caf93;
-  color: white;
   border: none;
 }
 
@@ -67,13 +71,9 @@
 }
 
 .node-system-container {
+  width: 70%;
   position: relative;
-  width: 100%;
-  min-height: 400px;
-  background-color: #333;
-  margin-bottom: 20px;
-  border-radius: 4px;
-  overflow: visible;
+  overflow: hidden;
 }
 
 .connection-svg {
@@ -96,6 +96,18 @@
   cursor: move;
   pointer-events: auto;
   z-index: 10;
+  color: white;
+  height: 45px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.node-title {
+  font-size: 14px;
+  font-weight: bold;
+  margin-bottom: 8px;
+  text-align: center;
 }
 
 .node-connector {
@@ -106,6 +118,7 @@
   cursor: pointer;
   transition: all 0.2s;
   z-index: 11;
+  border: 2px solid rgba(255, 255, 255, 0.2);
 }
 
 .node-connector.input {
@@ -127,7 +140,7 @@
   stroke: #4caf93;
   stroke-width: 2;
   fill: none;
-  transition: none;
+  pointer-events: stroke;
 }
 
 .connection-path:hover {
@@ -169,4 +182,81 @@
 .property-value {
   font-size: 14px;
   color: #666;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background-color: white;
+  padding: 24px;
+  border-radius: 8px;
+  min-width: 300px;
+}
+
+.modal-title {
+  margin: 0 0 16px;
+  font-size: 18px;
+  font-weight: bold;
+}
+
+.component-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.component-button {
+  padding: 12px;
+  border: none;
+  border-radius: 4px;
+  color: white;
+  font-weight: bold;
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+
+.component-button:hover {
+  transform: scale(1.05);
+}
+
+.canvas {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.connection-svg {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.connection-path {
+  stroke: #4caf93;
+  stroke-width: 2;
+  fill: none;
+  pointer-events: stroke;
+}
+
+.connection-path:hover {
+  stroke: #2a8059;
+  stroke-width: 3;
+}
+
+.connection-path.dragging {
+  stroke: #666;
+  stroke-dasharray: 5,5;
 }

--- a/src/components/ComponentSelector.tsx
+++ b/src/components/ComponentSelector.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import type { ComponentType } from '../types/node';
+
+interface ComponentSelectorProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (componentType: ComponentType) => void;
+}
+
+const components: { type: ComponentType; label: string; color: string }[] = [
+  { 
+    type: 'geometry', 
+    label: 'ジオメトリ', 
+    color: '#2196F3'  // 青系: 形状を表現
+  },
+  { 
+    type: 'texture', 
+    label: 'テクスチャ', 
+    color: '#9C27B0'  // 紫系: テクスチャ/画像表現
+  },
+  { 
+    type: 'composite', 
+    label: '合成処理', 
+    color: '#FF9800'  // オレンジ系: 処理/変換表現
+  },
+  { 
+    type: 'interaction', 
+    label: 'インタラクション', 
+    color: '#4CAF50'  // 緑系: インタラクティブ性表現
+  },
+];
+
+export const ComponentSelector: React.FC<ComponentSelectorProps> = ({
+  isOpen,
+  onClose,
+  onSelect,
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content">
+        <h2 className="modal-title">コンポーネントを選択</h2>
+        <div className="component-grid">
+          {components.map(({ type, label, color }) => (
+            <button
+              key={type}
+              className="component-button"
+              style={{ backgroundColor: color }}
+              onClick={() => {
+                onSelect(type);
+                onClose();
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/NodeBox.tsx
+++ b/src/components/NodeBox.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Draggable from 'react-draggable';
-import type { Node } from '../types/node';
+import type { Node, ComponentType } from '../types/node';
 
 interface NodeBoxProps {
   id: string;
@@ -12,6 +12,26 @@ interface NodeBoxProps {
 }
 
 export const NodeBox: React.FC<NodeBoxProps> = ({ id, node, position, onDrag, onStartConnection, onEndConnection })  => {
+  const getComponentColor = (type: ComponentType): string => {
+    switch (type) {
+      case 'geometry': return '#2196F3';
+      case 'texture': return '#9C27B0';
+      case 'composite': return '#FF9800';
+      case 'interaction': return '#4CAF50';
+      default: return '#333333';
+    }
+  };
+
+  const getComponentLabel = (type: ComponentType): string => {
+    switch (type) {
+      case 'geometry': return 'ジオメトリ';
+      case 'texture': return 'テクスチャ';
+      case 'composite': return '合成処理';
+      case 'interaction': return 'インタラクション';
+      default: return 'Node';
+    }
+  };
+
   return (
     <Draggable
       position={position}
@@ -19,31 +39,25 @@ export const NodeBox: React.FC<NodeBoxProps> = ({ id, node, position, onDrag, on
       bounds="parent"
       cancel=".node-connector"
     >
-      <div className="node-box">
-        <h3 className="node-title">Node {id}</h3>
+      <div 
+        className="node-box" 
+        style={{ backgroundColor: getComponentColor(node.componentType) }}
+      >
+        <div className="node-title">
+          {`${getComponentLabel(node.componentType)} ${node.componentNumber}`}
+        </div>
+        
         <div 
           className="node-connector input"
-          style={{ top: node.input.y }}
-          onMouseUp={(e) => {
-            e.stopPropagation();
-            onEndConnection(id, node.input.id, 'input', e);
-          }}
-          onMouseDown={(e) => {
-            e.stopPropagation();
-            onStartConnection(id, node.input.id, 'input', e);
-          }}
+          style={{ backgroundColor: '#3b82f6' }}
+          onMouseDown={(e) => onStartConnection(id, node.input.id, 'input', e)}
+          onMouseUp={(e) => onEndConnection(id, node.input.id, 'input', e)}
         />
         <div 
           className="node-connector output"
-          style={{ top: node.output.y }}
-          onMouseUp={(e) => {
-            e.stopPropagation();
-            onEndConnection(id, node.output.id, 'output', e);
-          }}
-          onMouseDown={(e) => {
-            e.stopPropagation();
-            onStartConnection(id, node.output.id, 'output', e);
-          }}
+          style={{ backgroundColor: '#10b981' }}
+          onMouseDown={(e) => onStartConnection(id, node.output.id, 'output', e)}
+          onMouseUp={(e) => onEndConnection(id, node.output.id, 'output', e)}
         />
       </div>
     </Draggable>

--- a/src/hooks/useNodeSystem.ts
+++ b/src/hooks/useNodeSystem.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { Node, DraggingConnection } from '../types/node';
+import type { Node, DraggingConnection, ComponentType } from '../types/node';
 
 export const useNodeSystem = () => {
   const [nodes, setNodes] = useState<Record<string, Node>>({});
@@ -10,25 +10,42 @@ export const useNodeSystem = () => {
     x: number;
     y: number;
   } | null>(null);
+  const [componentCounters, setComponentCounters] = useState<Record<ComponentType, number>>({
+    geometry: 0,
+    texture: 0,
+    composite: 0,
+    interaction: 0
+  });
 
-  const addNode = (id: string, position: { x: number; y: number }) => {
-    setNodes(prev => ({
-      ...prev,
-      [id]: {
-        id,
-        position,
-        input: {
-          id: `${id}-in`,
-          y: 30,
-          connections: []
-        },
-        output: {
-          id: `${id}-out`,
-          y: 30,
-          connections: []
+  const addNode = (id: string, options: { x: number; y: number; componentType: ComponentType }) => {
+    setNodes(prev => {
+      const currentCount = componentCounters[options.componentType];
+      
+      setComponentCounters(prevCounters => ({
+        ...prevCounters,
+        [options.componentType]: currentCount + 1
+      }));
+
+      return {
+        ...prev,
+        [id]: {
+          id,
+          position: { x: options.x, y: options.y },
+          componentType: options.componentType,
+          componentNumber: currentCount + 1,
+          input: {
+            id: `${id}-in`,
+            y: 30,
+            connections: []
+          },
+          output: {
+            id: `${id}-out`,
+            y: 30,
+            connections: []
+          }
         }
-      }
-    }));
+      };
+    });
   };
 
   const updateNodePosition = (id: string, position: { x: number; y: number }) => {

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -1,3 +1,5 @@
+export type ComponentType = 'geometry' | 'texture' | 'composite' | 'interaction';
+
 export interface NodePort {
   id: string;
   y: number;
@@ -9,6 +11,8 @@ export interface Node {
   position: { x: number; y: number };
   input: NodePort;
   output: NodePort;
+  componentType: ComponentType;
+  componentNumber: number;
 }
 
 export interface DraggingConnection {


### PR DESCRIPTION
## 概要
「Add Node」をクリックすると、追加するコンポーネントを追加できるようにする。
各コンポーネント名は、それぞれ一から増えるようにしている。

![pixieflow_add_compornent](https://github.com/user-attachments/assets/846202b0-bb65-4b38-b48b-f9fe33e30cb0)

## 検証環境
- Mac 
- Chrome
## 検証方法
- `docker compose build`, `docker compose up`
- http://localhost:12000 を開く。